### PR TITLE
Fix socket reuse error on Python 3.14+

### DIFF
--- a/wudao_dict/client.py
+++ b/wudao_dict/client.py
@@ -27,31 +27,26 @@ def _start_wudao_server():
     sleep(1)
     
     
-def _check_server(client: socket.socket, address: str, port: int) -> bool:
+def _check_server(address: str, port: int) -> Optional[socket.socket]:
     """
-    Check if the server running.
+    Check if the server running and return connected socket.
 
-    :param client: Socket client.
-    :type client: socket.socket
     :param address: Server address.
     :type address: str
     :param port: Server port.
     :type port: int
-    :return: True if the server running, else False.
-    :rtype: bool
+    :return: Connected socket if server is running, else None.
+    :rtype: Optional[socket.socket]
     """
-    check_res = False
-    
     for _ in range(5):
+        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             client.connect((address, port))
-            check_res = True
-            break
-        
-        except ConnectionRefusedError:
+            return client
+        except (ConnectionRefusedError, OSError):
+            client.close()
             sleep(0.2)
-            
-    return check_res
+    return None
 
 
 class WudaoClient:
@@ -60,45 +55,16 @@ class WudaoClient:
     """
     def __init__(self, address="127.0.0.1", port: Optional[int] = None):
         self.address = address
-        
+
         if port is None:
             self.port = read_socket()
         else:
             self.port = port
-            
+
         self._server_checked = False
-        self.client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        
-        # if self.port < 0:
-        #     _start_wudao_server()
-        #     has_call_start = True
-        #     port = read_socket()
-        #     
-        # else:
-        #     has_call_start = False
-        #     
-        # 
-        # # 检查后台服务。
-        # res = _check_server(self.client, address, port)
-        # fail_flag = False
-        # 
-        # if not res and not has_call_start:
-        #     # 如果连接失败且没有执行过启动函数，则尝试启动。
-        #     _start_wudao_server()
-        #     port = read_socket()
-        #     
-        #     if not _check_server(self.client, address, port):
-        #         fail_flag = True
-        # 
-        # elif not res:
-        #     fail_flag = True
-        #     
-        # if fail_flag:
-        #     print("[red]后台查询服务启动失败![red]")
-        #     print(f"[red]请试着检查日志文件[red]：{LOG_FILE}")
-        #     exit(1)
-            
-    def _check_server(self, no_start=False) -> bool:
+        self.client: Optional[socket.socket] = None
+
+    def _check_server_internal(self, no_start=False) -> bool:
         """
         Check background server.
 
@@ -109,76 +75,69 @@ class WudaoClient:
         """
         if self._server_checked:
             return True
-        
+
         if no_start:
             if self.port < 0:
                 return False
-            
-            if _check_server(self.client, self.address, self.port):
-                return True
-            
-            else:
-                return False
-        
+
+            self.client = _check_server(self.address, self.port)
+            return self.client is not None
+
         if self.port < 0:
             _start_wudao_server()
             has_call_start = True
             self.port = read_socket()
-            
+
         else:
             has_call_start = False
 
         # 检查后台服务。
-        res = _check_server(self.client, self.address, self.port)
-        fail_flag = False
-        
-        if not res and not has_call_start:
+        self.client = _check_server(self.address, self.port)
+
+        if self.client is None and not has_call_start:
             # 如果连接失败且没有执行过启动函数，则尝试启动。
             _start_wudao_server()
             self.port = read_socket()
-            
-            if not _check_server(self.client, self.address, self.port):
-                fail_flag = True
-        
-        elif not res:
-            fail_flag = True
-            
-        if fail_flag:
+            self.client = _check_server(self.address, self.port)
+
+        if self.client is None:
             print("[red]后台查询服务启动失败![red]")
             print(f"[red]请试着检查日志文件[red]：{LOG_FILE}")
             exit(1)
-            
+
         self._server_checked = True
-        
+
         return True
         
     def __enter__(self):
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.client.close()
-        
+        if self.client:
+            self.client.close()
+
     def __del__(self):
-        self.client.close()
-        
+        if self.client:
+            self.client.close()
+
     def close_server(self):
         """
         关闭无道词典服务进程。
         """
-        if self._check_server(no_start=True):
+        if self._check_server_internal(no_start=True):
             msg: QuitMessage = {"cmd": "quit"}
             self.client.sendall(dumps(msg).encode('utf-8'))
-    
+
     def get_word_info(self, word: str, online=True, update_db=True) -> str:
         """
         查询单词信息。
-        
+
         :param word: 要查询的单词
         :type word: str
         :return: 服务器返回的单词信息
         :rtype: str
         """
-        self._check_server()
+        self._check_server_internal()
         
         msg: QueryMessage = {
             "cmd": "query",


### PR DESCRIPTION
The _check_server function was reusing the same socket object across multiple connect() attempts. On Python 3.14, this causes OSError [Errno 22] Invalid argument because POSIX sockets cannot be reconnected after a failed connect() call. #3 

Changes:
- Create new socket for each connection attempt in _check_server
- Return connected socket on success, None on failure
- Add None checks in __exit__ and __del__ for lazy initialization
- Remove dead commented code from __init__

🤖 Generated with [Claude Code](https://claude.com/claude-code)